### PR TITLE
Links loaded by infinite scroll don't work

### DIFF
--- a/webroot/js/templates.js
+++ b/webroot/js/templates.js
@@ -6,7 +6,7 @@ window.templates = {
 
 	maintainer_link: function (p) {
 		return [
-			'<a href="/package/"' + p.Maintainer.username + '/' + p.Package.name + '" title="' + p.Package.name + '">',
+			'<a href="/package/' + p.Maintainer.username + '/' + p.Package.name + '" title="' + p.Package.name + '">',
 				p.Package.name,
 			'</a>'
 		].join("\n");


### PR DESCRIPTION
Noticed the issue on http://plugins.cakephp.org.

Root cause seems to be a minor typo in the maintainer_link template. Patch solves the issue.

Cheers!
