### PR TITLE
Use 2 columns for homepage's popular list

### DIFF
--- a/webroot/css/default/packages.css
+++ b/webroot/css/default/packages.css
@@ -223,6 +223,9 @@
 .packages-home .popular-list {
 	list-style: disc outside;
 	margin: 18px 0 18px 30px;
+	column-count: 2;
+	-webkit-column-count: 2;
+	-moz-column-count: 2;
 }
 .packages-home .popular-list li {
 	margin-bottom: 12px;


### PR DESCRIPTION
This gives a better look instead of large white space on the right of lists.
