### PR TITLE
Contrast text color for tag links & a fix

### DIFF
--- a/src/Template/Element/site/category.ctp
+++ b/src/Template/Element/site/category.ctp
@@ -4,6 +4,6 @@ if (empty($category->slug)) {
 }
 ?>
 
-<a href="/packages?category=<?php echo $category->slug; ?>" class="label category-label" style="background-color:<?php echo $category->getColor(); ?>">
+<a href="/packages?category=<?php echo $category->slug; ?>" class="label category-label" style="<?php echo $this->Resource->styleTag($category->getColor()); ?>">
     <?php echo $category->name; ?>
 </a>

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -11,6 +11,8 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ *
+ * @var \App\View\AppView $this
  */
 ?>
 <!DOCTYPE html>

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -23,6 +23,10 @@ use Cake\View\View;
  * Your application’s default view class
  *
  * @link http://book.cakephp.org/3.0/en/views.html#the-app-view
+ *
+ * @property \App\View\Helper\ResourceHelper $Resource
+ * @property \App\View\Helper\MenuHelper $Menu
+ * @property \AssetCompress\View\Helper\AssetCompressHelper $AssetCompress
  */
 class AppView extends View implements EventListenerInterface
 {
@@ -45,6 +49,7 @@ class AppView extends View implements EventListenerInterface
         $this->loadHelper('AssetCompress.AssetCompress');
         $this->loadHelper('Menu');
         $this->loadHelper('Form');
+        $this->loadHelper('Resource');
         $this->getEventManager()->on($this);
     }
 

--- a/src/View/Helper/ResourceHelper.php
+++ b/src/View/Helper/ResourceHelper.php
@@ -157,8 +157,9 @@ class ResourceHelper extends AppHelper
         $url = ['controller' => 'packages', 'action' => 'index'];
 
         if (isset($colorMap[$tag])) {
-            $queryString = ['version' => $key];
-            $options['style'] = sprintf('background-color:%s;', $colorMap[$tag]);
+            $queryString = ['version' => $value];
+            $url['?'] = $queryString;
+            $options['style'] = $this->styleTag($colorMap[$tag]);
             $version = strpos($key, '.') === false ? $value . '.x' : $value;
             return $this->Html->link('version:' . $version, $url, $options);
         }
@@ -172,7 +173,40 @@ class ResourceHelper extends AppHelper
         }
 
         $url['?'] = $queryString;
-        $options['style'] = sprintf('background-color:%s;color:white;', $color);
+        $options['style'] = $this->styleTag($color);
+
         return $this->Html->link($tag, $url, $options);
+    }
+
+    /**
+     * Calculates contrast text color for a given color
+     *
+     * @param string $color RGB color code with a leading "#"
+     *
+     * @return string Color
+     */
+    public function contrastColor($color)
+    {
+        if (hexdec(substr($color, 1)) / 0xFFFFFF < 0.5) {
+            return 'white';
+        }
+
+        return '#363637';
+    }
+
+    /**
+     * Generates a style tag
+     *
+     * @param string $color Color
+     *
+     * @return string Style
+     */
+    public function styleTag($color)
+    {
+        return sprintf(
+            'background-color:%s;color:%s',
+            $color,
+            $this->contrastColor($color)
+        );
     }
 }

--- a/tests/TestCase/View/Helper/ResourceHelperTest.php
+++ b/tests/TestCase/View/Helper/ResourceHelperTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\ResourceHelper;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+class ResourceHelperTest extends TestCase
+{
+    /**
+     * @var \App\View\Helper\ResourceHelper
+     */
+    public $Resource;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->View = new View();
+        $this->Resource = new ResourceHelper($this->View);
+        $this->_appNamespace = Configure::read('App.namespace');
+        static::setAppNamespace();
+    }
+
+    /**
+     * Test tagLink method.
+     */
+    public function testTagLink()
+    {
+        $expected = '<a href="/packages?has%5B0%5D=readme" class="label category-label" style="background-color:gray;color:white">has:readme</a>';
+        $result = $this->Resource->tagLink('has:readme');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test tagLink method.
+     */
+    public function testTagLinkVersion()
+    {
+        $expected = '<a href="/packages?version=2" class="label category-label" style="background-color:#9dd5c0;color:#363637">version:2.x</a>';
+        $result = $this->Resource->tagLink('version:2');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test tagLink method.
+     */
+    public function testTagContrastText()
+    {
+        $expected = '<a href="/packages?keyword%5B0%5D=cakephp" class="label category-label" style="background-color:darkgray;color:white">keyword:cakephp</a>';
+        $result = $this->Resource->tagLink('keyword:cakephp');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test contrastColor method.
+     */
+    public function testContrastColor()
+    {
+        $expected = '#363637';
+        $result = $this->Resource->contrastColor('#FFFFFF');
+        $this->assertSame($expected, $result);
+
+        $expected = 'white';
+        $result = $this->Resource->contrastColor('#000000');
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
Automatically calculate and use contrast text color in tags. Currently, some tags are barely readable.
Fixed links to a plugins list with a version filter.