### PR TITLE
Improve SyncPackagesCommand output, fix navbar dividers, reduce ddev healthcheck interval

### DIFF
--- a/.ddev/docker-compose.phpmyadmin.yaml
+++ b/.ddev/docker-compose.phpmyadmin.yaml
@@ -24,7 +24,7 @@ services:
       - HTTPS_EXPOSE=8037:80
     healthcheck:
       test: ["CMD-SHELL", "true"]
-      interval: 120s
+      interval: 5s
       timeout: 2s
       retries: 1
     depends_on:

--- a/.ddev/docker-compose.phpmyadmin.yaml
+++ b/.ddev/docker-compose.phpmyadmin.yaml
@@ -1,4 +1,3 @@
-#ddev-generated
 services:
   phpmyadmin:
     container_name: ddev-${DDEV_SITENAME}-phpmyadmin

--- a/src/Command/SyncPackagesCommand.php
+++ b/src/Command/SyncPackagesCommand.php
@@ -96,8 +96,24 @@ class SyncPackagesCommand extends Command
         $packagesTable = $this->fetchTable('Packages');
         $touchedIds = [];
 
-        $data = $this->client->all(['type' => 'cakephp-plugin']);
-        foreach ($data as $package) {
+        $io->out('Fetching package list from Packagist...');
+        $packages = $this->client->all(['type' => 'cakephp-plugin']);
+        $total = count($packages);
+        $io->out(sprintf('Found <info>%d</info> packages. Processing...', $total));
+
+        $saved = 0;
+        $skipped = 0;
+        $failed = 0;
+        $i = 0;
+
+        $progress = $io->helper('Progress');
+        $progress->init(['total' => $total, 'width' => 60]);
+        $io->out('', 0);
+
+        foreach ($packages as $package) {
+            $i++;
+            $io->out(sprintf('[%d/%d] %s', $i, $total, $package), 1, ConsoleIo::VERBOSE);
+
             $data = $this->getDataForPackage($package);
 
             if (
@@ -106,6 +122,8 @@ class SyncPackagesCommand extends Command
                 $data['downloads'] < 10 ||
                 !$this->hasExplicitCakePhpDependency($data['tag_list'])
             ) {
+                $skipped++;
+                $progress->increment()->draw();
                 continue;
             }
 
@@ -116,26 +134,49 @@ class SyncPackagesCommand extends Command
 
             $entity = $packagesTable->patchEntity($entity, $data);
             if (!$packagesTable->save($entity)) {
+                $failed++;
                 Log::warning('Unable to save package', [
-                    'package' => $package->getName(),
+                    'package' => $package,
                     'errors' => $entity->getErrors(),
                 ]);
+            } else {
+                $saved++;
             }
             $touchedIds[] = $entity->id;
+            $progress->increment()->draw();
         }
 
+        $io->out('');
+        $io->out(sprintf(
+            'Sync complete. Saved: <info>%d</info>, Skipped: <comment>%d</comment>, Failed: <error>%d</error>',
+            $saved,
+            $skipped,
+            $failed,
+        ));
+
         // Remove packages that were not touched
+        $io->out('Removing stale packages...');
+        $deleted = 0;
+        $deleteFailed = 0;
         /** @var \Cake\ORM\ResultSet<array-key, \App\Model\Entity\Package> $toDeletePackages */
         $toDeletePackages = $packagesTable->find()->where(['id NOT IN' => $touchedIds])->all();
         foreach ($toDeletePackages as $package) {
             if (!$packagesTable->delete($package)) {
+                $deleteFailed++;
                 Log::warning('Unable to delete package', [
                     'package' => $package->package,
                     'id' => $package->id,
                     'errors' => $package->getErrors(),
                 ]);
+            } else {
+                $deleted++;
             }
         }
+        $io->out(sprintf(
+            'Cleanup complete. Deleted: <info>%d</info>, Failed: <error>%d</error>',
+            $deleted,
+            $deleteFailed,
+        ));
     }
 
     /**

--- a/templates/element/navbar.php
+++ b/templates/element/navbar.php
@@ -50,8 +50,7 @@
                                 </div>
                             </div>
                         </li>
-                        <li role="separator" class="p-0"><hr class="divider my-0" /></li>
-                        <li>
+                        <li class="border-t border-base-300 pt-1">
                             <?= $this->Html->link('Sign out', [
                                 'controller' => 'Users',
                                 'action' => 'logout',
@@ -92,8 +91,7 @@
                     <li><?= $this->Html->link('Docs', 'https://book.cakephp.org/', ['target' => '_blank', 'rel' => 'noopener']) ?></li>
                     <li><?= $this->Html->link('API', 'https://api.cakephp.org/', ['target' => '_blank', 'rel' => 'noopener']) ?></li>
                     <?php if (!$this->Identity->isLoggedIn()) : ?>
-                        <li role="separator" class="p-0"><hr class="divider my-0" /></li>
-                        <li>
+                        <li class="border-t border-base-300 pt-1">
                             <?= $this->Form->postLink(
                                 'Sign in with GitHub',
                                 [


### PR DESCRIPTION
## Changes

### `SyncPackagesCommand` — progress & stats output
- Add a progress bar while processing packages
- Track and display counters for saved, skipped, and failed packages
- Add verbose per-package logging (`[i/total] package-name`)
- Print a summary after the sync phase and after the stale-package cleanup phase
- Fix incorrect `$package->getName()` call in the warning log (was passing the wrong type)

### Navbar dropdown dividers
- Replace the separate `<li role="separator">` + `<hr>` element pattern with a single `<li class="border-t border-base-300 pt-1">`, using Tailwind/DaisyUI border utilities

### ddev phpMyAdmin healthcheck
- Decrease the healthcheck interval from `120s` to `5s` so the container is marked healthy much faster on startup